### PR TITLE
Fix #5752 Weld injector reinitialization

### DIFF
--- a/com.ibm.jbatch.container/pom.xml
+++ b/com.ibm.jbatch.container/pom.xml
@@ -131,7 +131,7 @@
 					<systemPropertyVariables>
 						<com.ibm.jbatch.spi.ServiceRegistry.J2SE_MODE>true</com.ibm.jbatch.spi.ServiceRegistry.J2SE_MODE>
 						<com.ibm.jbatch.spi.ServiceRegistry.BATCH_THREADPOOL_SERVICE>com.ibm.jbatch.container.services.impl.GrowableThreadPoolServiceImpl</com.ibm.jbatch.spi.ServiceRegistry.BATCH_THREADPOOL_SERVICE>
-						<com.ibm.jbatch.spi.ServiceRegistry.CONTAINER_ARTIFACT_FACTORY_SERVICE>com.ibm.jbatch.container.services.impl.DelegatingBatchArtifactFactoryImpl</com.ibm.jbatch.spi.ServiceRegistry.CONTAINER_ARTIFACT_FACTORY_SERVICE>
+						<com.ibm.jbatch.spi.ServiceRegistry.CONTAINER_ARTIFACT_FACTORY_SERVICE>com.ibm.jbatch.container.services.impl.WeldSEBatchArtifactFactoryImpl</com.ibm.jbatch.spi.ServiceRegistry.CONTAINER_ARTIFACT_FACTORY_SERVICE>
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>

--- a/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/cdi/BatchCDIInjectionExtension.java
+++ b/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/cdi/BatchCDIInjectionExtension.java
@@ -27,13 +27,8 @@ import javax.enterprise.inject.spi.Extension;
 
 public class BatchCDIInjectionExtension implements Extension {
 
-    private final static String sourceClass = BatchProducerBean.class.getName();
-    private final static Logger logger = Logger.getLogger(sourceClass);
+    private final static Logger logger = Logger.getLogger(BatchCDIInjectionExtension.class.getName());
 
-
-
-
-    
     void beforeBeanDiscovery(@Observes BeforeBeanDiscovery bbd, BeanManager bm) {
 
         logger.log(Level.FINE, "BatchCDIInjectionExtension.beforeBeanDiscovery() bm=" + bm);
@@ -43,5 +38,4 @@ public class BatchCDIInjectionExtension implements Extension {
         
         logger.log(Level.FINE, "BatchCDIInjectionExtension.beforeBeanDiscovery() added annotated type: " + BatchProducerBean.class.getName());
     }
-
 }

--- a/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/cdi/BatchProducerBean.java
+++ b/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/cdi/BatchProducerBean.java
@@ -17,7 +17,6 @@
 package com.ibm.jbatch.container.cdi;
 
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.batch.api.BatchProperty;
 import javax.batch.runtime.context.JobContext;
@@ -31,53 +30,36 @@ import com.ibm.jbatch.container.util.DependencyInjectionUtility;
 import com.ibm.jbatch.jsl.model.Property;
 
 public class BatchProducerBean {
-    
-    private final static String sourceClass = BatchProducerBean.class.getName();
-    private final static Logger logger = Logger.getLogger(sourceClass);
 
     @Produces
     @Dependent
     @BatchProperty
     public String produceProperty(InjectionPoint injectionPoint) {
-
-        //Seems like this is a CDI bug where null injection points are getting passed in. 
-        //We should be able to ignore these as a workaround.
-        if (injectionPoint != null) {
-
-            if (ProxyFactory.getInjectionReferences() == null) {
-                return null;
-            }
-            
-            
-            BatchProperty batchPropAnnotation = injectionPoint.getAnnotated().getAnnotation(BatchProperty.class);
-
-            // If a name is not supplied the batch property name defaults to
-            // the field name
-            String batchPropName = null;
-            if (batchPropAnnotation.name().equals("")) {
-                batchPropName = injectionPoint.getMember().getName();
-            } else {
-                batchPropName = batchPropAnnotation.name();
-            }
-
-            List<Property> propList = ProxyFactory.getInjectionReferences().getProps();
-
-            String propValue =  DependencyInjectionUtility.getPropertyValue(propList, batchPropName);
-            
-            return propValue;
-            
+        if (ProxyFactory.getInjectionReferences() == null) {
+            return null;
         }
 
-        return null;
+        BatchProperty batchPropAnnotation = injectionPoint.getAnnotated().getAnnotation(BatchProperty.class);
 
+        // If a name is not supplied the batch property name defaults to
+        // the field name
+        String batchPropName;
+        if (batchPropAnnotation.name().equals("")) {
+            batchPropName = injectionPoint.getMember().getName();
+        } else {
+            batchPropName = batchPropAnnotation.name();
+        }
+
+        List<Property> propList = ProxyFactory.getInjectionReferences().getProps();
+
+        return DependencyInjectionUtility.getPropertyValue(propList, batchPropName);
     }
 
     @Produces
     @Dependent
     public JobContext getJobContext() {
-        
         if (ProxyFactory.getInjectionReferences() != null) {
-                return ProxyFactory.getInjectionReferences().getJobContext();
+            return ProxyFactory.getInjectionReferences().getJobContext();
         } else {
             return null;
         }
@@ -86,17 +68,10 @@ public class BatchProducerBean {
     @Produces
     @Dependent
     public StepContext getStepContext() {
-        
         if (ProxyFactory.getInjectionReferences() != null) {
             return ProxyFactory.getInjectionReferences().getStepContext();
         } else {
             return null;
         }
-        
     }
-
-
-
-
-
 }

--- a/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/services/impl/WeldSEBatchArtifactFactoryImpl.java
+++ b/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/services/impl/WeldSEBatchArtifactFactoryImpl.java
@@ -38,6 +38,8 @@ public class WeldSEBatchArtifactFactoryImpl implements IBatchArtifactFactory {
 
     // TODO - synchronize appropriately once we learn more about usage
     private boolean loaded = false;
+    private Weld weld;
+    private WeldContainer container;
 
     // Uses TCCL
     @Override
@@ -51,9 +53,9 @@ public class WeldSEBatchArtifactFactoryImpl implements IBatchArtifactFactory {
         Object loadedArtifact = getArtifactById(batchId);
 
         if (loadedArtifact == null) {
-            
+
             logger.exiting(CLASSNAME, methodName, "Returning null artifact for id: " + batchId);
-            
+
             return loadedArtifact;
 
         }
@@ -67,37 +69,31 @@ public class WeldSEBatchArtifactFactoryImpl implements IBatchArtifactFactory {
 
     private Object getArtifactById(String id) {
 
-
-        
         Object artifactInstance = null;
 
         try {
-        WeldContainer weld = new Weld().initialize();
-        BeanManager bm = weld.getBeanManager();
+            final BeanManager bm = container.getBeanManager();
 
-        Bean bean = bm.getBeans(id).iterator().next();
+            final Bean<?> bean = bm.resolve(bm.getBeans(id));
 
-        Class clazz = bean.getBeanClass();
-        
-        artifactInstance = bm.getReference(bean, clazz, bm.createCreationalContext(bean));
+            final Class clazz = bean.getBeanClass();
+
+            artifactInstance = bm.getReference(bean, clazz, bm.createCreationalContext(bean));
         } catch (Exception e) {
             // Don't throw an exception but simply return null;
             logger.fine("Tried but failed to load artifact with id: " + id + ", Exception = " + e);
         }
         return artifactInstance;
-        
     }
 
     @Override
     public void init(IBatchConfig batchConfig) throws BatchContainerServiceException {
-        // TODO Auto-generated method stub
-
+        weld = new Weld();
+        container = weld.initialize();
     }
 
     @Override
     public void shutdown() throws BatchContainerServiceException {
-        // TODO Auto-generated method stub
-
+        weld.shutdown();
     }
-
 }

--- a/com.ibm.jbatch.container/src/test/java/test/artifacts/WeldArtifactFactoryBatchlet.java
+++ b/com.ibm.jbatch.container/src/test/java/test/artifacts/WeldArtifactFactoryBatchlet.java
@@ -1,0 +1,34 @@
+package test.artifacts;
+
+import javax.batch.api.Batchlet;
+import javax.enterprise.inject.New;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+/**
+ * @author <a href="mailto:brent.n.douglas@gmail.com">Brent Douglas</a>
+ */
+public class WeldArtifactFactoryBatchlet implements Batchlet {
+
+    public static boolean produced = false;
+
+    @Produces
+    @Named("weldArtifactFactoryBatchlet")
+    public WeldArtifactFactoryBatchlet produce(final @New WeldArtifactFactoryBatchlet that) {
+        produced = true;
+        return that;
+    }
+
+	@Override
+	public String process() throws Exception {
+        if (!produced) {
+            throw new RuntimeException("Not loaded from CDI");
+        }
+        return null;
+	}
+	
+	@Override
+	public void stop() {
+        // no op
+	}
+}

--- a/com.ibm.jbatch.container/src/test/java/test/junit/WeldTest.java
+++ b/com.ibm.jbatch.container/src/test/java/test/junit/WeldTest.java
@@ -1,0 +1,55 @@
+package test.junit;
+
+import com.ibm.jbatch.container.api.impl.JobOperatorImpl;
+import com.ibm.jbatch.container.services.impl.DelegatingBatchArtifactFactoryImpl;
+import com.ibm.jbatch.container.services.impl.WeldSEBatchArtifactFactoryImpl;
+import com.ibm.jbatch.container.servicesmanager.ServiceTypes;
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.batch.operations.JobOperator;
+import javax.batch.operations.NoSuchJobException;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.StepExecution;
+
+/**
+ * @author <a href="mailto:brent.n.douglas@gmail.com">Brent Douglas</a>
+ */
+public class WeldTest {
+
+    private static JobOperator operator;
+
+    @BeforeClass
+    public static void beforeClass() {
+        operator = new JobOperatorImpl();
+    }
+
+    @Test
+    public void testWeldWorks() throws InterruptedException {
+        final JobExecution job = awaitJob("weldArtifactFactoryTest");
+        Assert.assertEquals(BatchStatus.COMPLETED, job.getBatchStatus());
+
+        final StepExecution step = operator.getStepExecutions(job.getExecutionId()).get(0);
+        Assert.assertEquals(BatchStatus.COMPLETED, step.getBatchStatus());
+    }
+
+    private JobExecution awaitJob(final String job) {
+        final long id = operator.start(job, null);
+
+        try {
+            for (;;) {
+                operator.getRunningExecutions(job);
+                try {
+                    Thread.sleep(100);
+                } catch (final InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        } catch (final NoSuchJobException e) {
+            return operator.getJobExecution(id);
+        }
+    }
+}

--- a/com.ibm.jbatch.container/src/test/resources/META-INF/batch-jobs/weldArtifactFactoryTest.xml
+++ b/com.ibm.jbatch.container/src/test/resources/META-INF/batch-jobs/weldArtifactFactoryTest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2012 International Business Machines Corp.
+  
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License, 
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+  
+    http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  @author <a href="mailto:brent.n.douglas@gmail.com">Brent Douglas</a>
+-->
+<job xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd"
+     id="weldArtifactFactoryTest" version="1.0">
+	<step id="step1">
+		<batchlet ref="weldArtifactFactoryBatchlet"/>
+	</step>
+</job>

--- a/com.ibm.jbatch.container/src/test/resources/META-INF/beans.xml
+++ b/com.ibm.jbatch.container/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>


### PR DESCRIPTION
Initialize weld once when the injector is initialized rather than per
lookup. Also changes the injector to use BeanManager#resolve rather
than cycling through matching beans.