### PR TITLE
[#6155] Make ExternalizableString externalizable

### DIFF
--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/reusable/ExternalizableString.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/reusable/ExternalizableString.java
@@ -23,6 +23,15 @@ import java.io.ObjectOutput;
 
 public class ExternalizableString implements Externalizable {
 
+	private String string;
+
+	public ExternalizableString() {
+	}
+
+	public ExternalizableString(final String string) {
+		this.string = string;
+	}
+
 	public String getString() {
 		return string;
 	}
@@ -36,25 +45,14 @@ public class ExternalizableString implements Externalizable {
 		return this.string;
 	}
 	
-	private String string;
-	
-	public ExternalizableString(String string) {
-		this.string = string;
-	}
-	
 	@Override
 	public void readExternal(ObjectInput in) throws IOException,
 			ClassNotFoundException {
-		
 		string = (String)in.readObject();
-
 	}
 
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException {
-		
 		out.writeObject(string);
-
 	}
-
 }


### PR DESCRIPTION
Provides ExternalizableString with a public no arg constructor required
when they are being reconstructed.
