### PR TITLE
Remove unused maven-bundle-plugin.

### DIFF
--- a/javax.batch/pom.xml
+++ b/javax.batch/pom.xml
@@ -109,27 +109,6 @@
 				</executions>
 			</plugin>
 -->
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<version>1.4.3</version>
-				<configuration>
-					<supportedProjectTypes>
-						<supportedProjectType>jar</supportedProjectType>
-					</supportedProjectTypes>
-					<instructions>
-						<Bundle-Version>${spec.bundle.version}</Bundle-Version>
-						<Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-						<Extension-Name>${spec.extension.name}</Extension-Name>
-						<Implementation-Version>${spec.implementation.version}</Implementation-Version>
-						<Specification-Version>${spec.specification.version}</Specification-Version>
-						<Bundle-Description>
-							Bundle Description
-						</Bundle-Description>
-					</instructions>
-				</configuration>
-			</plugin>
-
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This plugin is not used, as the manifest is provided as a resource, and it doesn't look like it is configured correctly anyway as it is referencing properties that are not defined in the project.
