### PR TITLE
[#6415] Remove redundant System.out log message

### DIFF
--- a/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/impl/SkipHandler.java
+++ b/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/impl/SkipHandler.java
@@ -258,7 +258,6 @@ public class SkipHandler {
 	    }
 	    else
 	    {
-	      System.out.println("## NO SKIP");
 	      // No skip.  Throw it back. - No, exit without throwing
 	      if(logger.isLoggable(Level.FINER)) 
 	        logger.logp(Level.FINE, className, mName, "No skip.  Rethrow ", e);


### PR DESCRIPTION
An almost identical message is sent to the java.uitl.Logger anyway.
