### PR TITLE
[#5833] Ant sets exit code to 1 if TCK tests fail

### DIFF
--- a/com.ibm.jbatch.tck/src/main/resources/testng/build.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/testng/build.xml
@@ -54,7 +54,7 @@
         					<pathelement path="${batch.impl.classes}"/> 
         			</path>
 	
-		<testng mode="testng" classpathref="jsr352.tck.classpath" dumpCommand="true" workingDir="." failureProperty="tests.failed" outputdir="${results}">
+		<testng mode="testng" classpathref="jsr352.tck.classpath" dumpCommand="true" workingDir="." haltonfailure="true" outputdir="${results}">
 			
 			<xmlfileset dir="." includes="artifacts/jsr352-tck-impl-suite.xml"/>
 			


### PR DESCRIPTION
The 'tests.failed' property was never checked so tell ant to return 1 on failure instead.  
