### PR TITLE
added extension location for a container to provide override properties

### DIFF
--- a/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/servicesmanager/ServicesManagerImpl.java
+++ b/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/servicesmanager/ServicesManagerImpl.java
@@ -183,6 +183,8 @@ public class ServicesManagerImpl implements BatchContainerConstants, ServicesMan
 		batchContainerProps = new Properties();
 		batchContainerProps.putAll(adminProps);
 		batchContainerProps.putAll(serviceIntegratorProps);
+                //Merge in overrides from the SPI so the container can change properties
+                batchContainerProps.putAll(BatchSPIManager.getInstance().getBatchContainerOverrideProperties());
 
 		logger.fine("Dumping contents of batchContainerProps after reading properties files.");
 		for (Object key : batchContainerProps.keySet()) {

--- a/com.ibm.jbatch.spi/src/main/java/com/ibm/jbatch/spi/BatchSPIManager.java
+++ b/com.ibm.jbatch.spi/src/main/java/com/ibm/jbatch/spi/BatchSPIManager.java
@@ -16,12 +16,14 @@
  */
 package com.ibm.jbatch.spi;
 
+import java.util.Properties;
 import java.util.logging.Logger;
 
 public final class BatchSPIManager {
 
 	private final static String sourceClass = BatchSPIManager.class.getName();
 	private final static Logger logger = Logger.getLogger(sourceClass);
+        private Properties overrideProperties = new Properties();
 
 	private BatchSPIManager() {}
 	
@@ -61,6 +63,10 @@ public final class BatchSPIManager {
 	public ExecutorServiceProvider getExecutorServiceProvider() {
 		return executorServiceProvider;
 	}
+        
+        public Properties getBatchContainerOverrideProperties() {
+            return overrideProperties;
+        }
 
 	/**
 	 * May be called at any point and will be immediately reflected in the singleton,
@@ -88,6 +94,13 @@ public final class BatchSPIManager {
 	public void registerExecutorServiceProvider(ExecutorServiceProvider provider) {
 		this.executorServiceProvider = provider;
 	}
+        
+        /**
+         * Override container properties read from META-INF
+         */
+        public void registerBatchContainerOverrideProperties(Properties properties) {
+            this.overrideProperties.putAll(properties);
+        }
 	
 	private final byte[] databaseConfigurationCompleteLock = new byte[0];
 	private Boolean databaseConfigurationComplete = Boolean.FALSE;


### PR DESCRIPTION
Provides an extension point for GlassFish to override service implementations by providing properties to override those read from the META-INF.

Fix #12 
