### PR TITLE
fix issue11 by using 'USE schema_name' on mysql 

### DIFF
--- a/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/services/impl/JDBCPersistenceManagerImpl.java
+++ b/com.ibm.jbatch.container/src/main/java/com/ibm/jbatch/container/services/impl/JDBCPersistenceManagerImpl.java
@@ -392,10 +392,15 @@ public class JDBCPersistenceManagerImpl implements IPersistenceManagerService, J
 	private void setSchemaOnConnection(Connection connection) throws SQLException {
 		logger.finest("Entering " + CLASSNAME +".setSchemaOnConnection()");
 
-		if (!"Oracle".equals(connection.getMetaData().getDatabaseProductName())) {
+		String dbProductName = connection.getMetaData().getDatabaseProductName();
+		if (!"Oracle".equals(dbProductName)) {
 			PreparedStatement ps = null;
-			ps = connection.prepareStatement("SET SCHEMA ?");
-			ps.setString(1, schema);
+			if ("MySQL".equals(dbProductName)) {
+				ps = connection.prepareStatement("USE " + schema);
+			} else {
+				ps = connection.prepareStatement("SET SCHEMA ?");
+				ps.setString(1, schema);
+			}
 			ps.executeUpdate(); 
 			ps.close();
 		}


### PR DESCRIPTION
This change is to fix https://github.com/WASdev/standards.jsr352.jbatch/issues/11.
It updates method setSchemaOnConnection in JDBCPersistenceManagerImpl.java to use 'USE schema_name' instead of 'SET SCHEMA' on mysql.
